### PR TITLE
fix: allowlist Staticman public recaptcha key

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,11 @@
+title = "blog gitleaks config"
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Staticman reCAPTCHA public site key in historical config"
+regexTarget = "line"
+regexes = [
+  '''siteKey:\s*"6Lcv8G8UAAAAAEqV1Y-XEPum00C_DxhD6O--qkFo"''',
+]


### PR DESCRIPTION
## Summary
- Adds a gitleaks config using the default ruleset.
- Allowlists the Staticman reCAPTCHA public site key line that is present in historical config and caused the scheduled Supply Chain Audit to fail.

## Verification
- gitleaks detect --redact -v --exit-code=2
- bundle-audit check --update
- Docker digest pinning check
- GitHub Actions SHA pinning check
- node --test tests/main.test.js

Root cause: gitleaks flagged the Staticman reCAPTCHA siteKey in staticman.yml history as generic-api-key. reCAPTCHA site keys are public identifiers; the allowlist is narrowed to the exact historical siteKey line.